### PR TITLE
fix(cms): use published Notion domain for content

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ NEXT_PUBLIC_CATEGORY_ID=
 NOTION_TOKEN=
 NOTION_DATABASE_ID=
 NOTION_DATA_SOURCE_ID=
+# Published workspace domain used by notion-client for page content.
+NOTION_PUBLIC_SITE_URL=https://future-shawl-a38.notion.site
 
 # pages (optional)
 NOTION_NOTE_PAGE_ID=

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,52 +1,46 @@
-# Task 2 Report: Add persistent Notion cache wrappers
+# Task 2 Report: Show content fetch failure state
 
-## Scope
+## Status
 
-Implemented persistent Next.js caching for all Notion reads used by the post actions. Task 1 code was not changed except for the required integration in `app/posts/actions/posts.ts`.
+DONE
 
-## Changes
+## Files
 
-- Added `lib/notion-cache.ts` with five-minute `unstable_cache` wrappers for:
-  - Post metadata (`pages.retrieve`)
-  - Post content record maps (`getPage`)
-  - Static page content (`getPage` with a page-type cache key)
-  - Post dates (`dataSources.query`)
-  - Cursor-paginated post list pages (`dataSources.query`)
-- Added stable cache-key builders that include every result-affecting input, including data source ID, status, category, cursor, and page size for list pages.
-- Applied the required cache tags:
-  - `notion:posts`
-  - `notion:post:{id}`
-  - `notion:page:{type}`
-  - `notion:post-dates`
-- Kept content caches bounded at five-minute revalidation so signed Notion asset URLs are not cached indefinitely.
-- Routed all Notion reads in `posts.ts` through the cache wrappers while preserving existing `[]`/`null` fallbacks and error logging. React `cache()` remains only around action functions for request-level deduplication.
-- Added focused unit tests for key stability, tag/revalidation configuration, API routing, and signed-content cache lifetime.
+- `app/posts/[slug]/page.tsx`
+  - Passes a missing record map through to the client boundary instead of omitting the post content boundary.
+- `app/posts/[slug]/components/PostPageClient.tsx`
+  - Accepts `ExtendedRecordMap | null`.
+  - Renders `Article content is temporarily unavailable.` only for a missing record map, without adding a wrapper.
+  - Preserves the prior successful fragment containing `Content` and `PostSummaryClient` unchanged.
+- `app/posts/actions/posts.ts`
+  - Sanitizes content-fetch failure logs to page ID and configured Notion endpoint hostname only.
+- `tests/integration/components/PostPageClient.test.tsx`
+  - Covers the missing record-map fallback and verifies the successful DOM tree has no added wrapper.
 
-## TDD Evidence
+## Commit
 
-1. Added `tests/unit/lib/notion-cache.test.ts` before the cache implementation.
-2. Ran the focused test red:
+`fix(posts): preserve content success markup`
 
-   ```text
-   bun vitest run tests/unit/lib/notion-cache.test.ts
-   Error: Failed to resolve import "@/lib/notion-cache"
-   ```
+## Test
 
-3. Implemented the cache wrappers and `posts.ts` integration.
-4. Ran the focused tests green:
+Command:
 
-   ```text
-   bun vitest run tests/unit/lib/notion-cache.test.ts tests/unit/helpers/post-query.test.ts
-   Test Files 2 passed; Tests 8 passed
-   ```
+```text
+bun vitest run tests/integration/components/PostPageClient.test.tsx
+```
 
-5. Ran the TypeScript check:
+Output:
 
-   ```text
-   bun x tsc --noEmit --pretty false
-   passed with no output
-   ```
+```text
+ RUN  v4.1.0 D:/Github/next-level-blog/.worktrees/published-notion-domain
+
+
+ Test Files  1 passed (1)
+      Tests  2 passed (2)
+   Start at  23:43:04
+   Duration 1.79s (transform 124ms, setup 172ms, import 372ms, tests 67ms, environment 946ms)
+```
 
 ## Concerns
 
-- Cache key values are built from Notion IDs and query strings; these are expected to be stable deployment inputs. No known functional concerns remain.
+None known. The existing metadata error handling remains unchanged; content-fetch logs no longer include caught error objects.

--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,46 +1,52 @@
-# Task 2 Report: Show content fetch failure state
+# Task 2 Report: Add persistent Notion cache wrappers
 
-## Status
+## Scope
 
-DONE
+Implemented persistent Next.js caching for all Notion reads used by the post actions. Task 1 code was not changed except for the required integration in `app/posts/actions/posts.ts`.
 
-## Files
+## Changes
 
-- `app/posts/[slug]/page.tsx`
-  - Passes a missing record map through to the client boundary instead of omitting the post content boundary.
-- `app/posts/[slug]/components/PostPageClient.tsx`
-  - Accepts `ExtendedRecordMap | null`.
-  - Renders `Article content is temporarily unavailable.` only for a missing record map, without adding a wrapper.
-  - Preserves the prior successful fragment containing `Content` and `PostSummaryClient` unchanged.
-- `app/posts/actions/posts.ts`
-  - Sanitizes content-fetch failure logs to page ID and configured Notion endpoint hostname only.
-- `tests/integration/components/PostPageClient.test.tsx`
-  - Covers the missing record-map fallback and verifies the successful DOM tree has no added wrapper.
+- Added `lib/notion-cache.ts` with five-minute `unstable_cache` wrappers for:
+  - Post metadata (`pages.retrieve`)
+  - Post content record maps (`getPage`)
+  - Static page content (`getPage` with a page-type cache key)
+  - Post dates (`dataSources.query`)
+  - Cursor-paginated post list pages (`dataSources.query`)
+- Added stable cache-key builders that include every result-affecting input, including data source ID, status, category, cursor, and page size for list pages.
+- Applied the required cache tags:
+  - `notion:posts`
+  - `notion:post:{id}`
+  - `notion:page:{type}`
+  - `notion:post-dates`
+- Kept content caches bounded at five-minute revalidation so signed Notion asset URLs are not cached indefinitely.
+- Routed all Notion reads in `posts.ts` through the cache wrappers while preserving existing `[]`/`null` fallbacks and error logging. React `cache()` remains only around action functions for request-level deduplication.
+- Added focused unit tests for key stability, tag/revalidation configuration, API routing, and signed-content cache lifetime.
 
-## Commit
+## TDD Evidence
 
-`fix(posts): preserve content success markup`
+1. Added `tests/unit/lib/notion-cache.test.ts` before the cache implementation.
+2. Ran the focused test red:
 
-## Test
+   ```text
+   bun vitest run tests/unit/lib/notion-cache.test.ts
+   Error: Failed to resolve import "@/lib/notion-cache"
+   ```
 
-Command:
+3. Implemented the cache wrappers and `posts.ts` integration.
+4. Ran the focused tests green:
 
-```text
-bun vitest run tests/integration/components/PostPageClient.test.tsx
-```
+   ```text
+   bun vitest run tests/unit/lib/notion-cache.test.ts tests/unit/helpers/post-query.test.ts
+   Test Files 2 passed; Tests 8 passed
+   ```
 
-Output:
+5. Ran the TypeScript check:
 
-```text
- RUN  v4.1.0 D:/Github/next-level-blog/.worktrees/published-notion-domain
-
-
- Test Files  1 passed (1)
-      Tests  2 passed (2)
-   Start at  23:43:04
-   Duration 1.79s (transform 124ms, setup 172ms, import 372ms, tests 67ms, environment 946ms)
-```
+   ```text
+   bun x tsc --noEmit --pretty false
+   passed with no output
+   ```
 
 ## Concerns
 
-None known. The existing metadata error handling remains unchanged; content-fetch logs no longer include caught error objects.
+- Cache key values are built from Notion IDs and query strings; these are expected to be stable deployment inputs. No known functional concerns remain.

--- a/app/posts/[slug]/components/PostPageClient.tsx
+++ b/app/posts/[slug]/components/PostPageClient.tsx
@@ -5,7 +5,7 @@ import PostSummaryClient from "./PostSummaryClient";
 import type { ExtendedRecordMap } from "notion-types";
 
 interface PostPageClientProps {
-  recordMap: ExtendedRecordMap;
+  recordMap: ExtendedRecordMap | null;
   slug: string;
 }
 
@@ -14,9 +14,15 @@ export default function PostPageClient({
   slug,
 }: PostPageClientProps) {
   return (
-    <>
-      <Content recordMap={recordMap} />
-      <PostSummaryClient recordMap={recordMap} slug={slug} />
-    </>
+    <article>
+      {recordMap ? (
+        <>
+          <Content recordMap={recordMap} />
+          <PostSummaryClient recordMap={recordMap} slug={slug} />
+        </>
+      ) : (
+        <p role="status">Article content is temporarily unavailable.</p>
+      )}
+    </article>
   );
 }

--- a/app/posts/[slug]/components/PostPageClient.tsx
+++ b/app/posts/[slug]/components/PostPageClient.tsx
@@ -13,16 +13,12 @@ export default function PostPageClient({
   recordMap,
   slug,
 }: PostPageClientProps) {
-  return (
-    <article>
-      {recordMap ? (
-        <>
-          <Content recordMap={recordMap} />
-          <PostSummaryClient recordMap={recordMap} slug={slug} />
-        </>
-      ) : (
-        <p role="status">Article content is temporarily unavailable.</p>
-      )}
-    </article>
+  return recordMap ? (
+    <>
+      <Content recordMap={recordMap} />
+      <PostSummaryClient recordMap={recordMap} slug={slug} />
+    </>
+  ) : (
+    <p role="status">Article content is temporarily unavailable.</p>
   );
 }

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -42,7 +42,7 @@ const Post = async ({ params }: Props) => {
 
   return (
     <Suspense fallback={<Loader />}>
-      {recordMap && <PostPageClient recordMap={recordMap} slug={slug} />}
+      <PostPageClient recordMap={recordMap} slug={slug} />
     </Suspense>
   );
 };

--- a/app/posts/actions/posts.ts
+++ b/app/posts/actions/posts.ts
@@ -171,6 +171,17 @@ export const fetchAllPosts = cache(async (): Promise<PageDataSchemaType[]> => {
   return page.items;
 });
 
+const getNotionEndpointHostname = (): string => {
+  const configuredEndpoint = process.env.NOTION_PUBLIC_SITE_URL;
+  if (!configuredEndpoint) return "unknown";
+
+  try {
+    return new URL(configuredEndpoint).hostname;
+  } catch {
+    return "invalid";
+  }
+};
+
 /**
  * Fetches a single post by its ID.
  */
@@ -205,8 +216,10 @@ export const fetchPostContent = cache(
 
     try {
       return await getCachedPostContent(pageId);
-    } catch (error) {
-      console.error(`Failed to fetch content for page ${pageId}:`, error);
+    } catch {
+      console.error(
+        `Failed to fetch content for page ${pageId} from ${getNotionEndpointHostname()}`,
+      );
       return null;
     }
   },
@@ -230,8 +243,10 @@ export const fetchStaticPageContent = cache(
 
     try {
       return await getCachedStaticPageContent(type, pageId);
-    } catch (error) {
-      console.error(`Failed to fetch content for page ${pageId}:`, error);
+    } catch {
+      console.error(
+        `Failed to fetch content for page ${pageId} from ${getNotionEndpointHostname()}`,
+      );
       return null;
     }
   },

--- a/docs/WORKFLOW.md
+++ b/docs/WORKFLOW.md
@@ -209,6 +209,7 @@ Two separate Notion clients are used together:
 ```env
 NOTION_TOKEN                # Official client auth
 NOTION_DATA_SOURCE_ID       # Database for post queries
+NOTION_PUBLIC_SITE_URL      # Published Notion workspace domain for page content
 NOTION_ABOUT_PAGE_ID        # About static page
 NOTION_NOTE_PAGE_ID         # Notes static page
 NOTION_PROJECT_PAGE_ID      # Projects/Hobbies static page
@@ -218,6 +219,12 @@ NEXT_PUBLIC_REPO            # Giscus comments
 NEXT_PUBLIC_REPO_ID         # Giscus comments
 NEXT_PUBLIC_CATEGORY_ID     # Giscus discussion category
 ```
+
+`NOTION_PUBLIC_SITE_URL` must identify the published Notion workspace domain (for
+example, `https://future-shawl-a38.notion.site`). Every page rendered through
+`notion-client` must be published under this configured domain. Set this
+variable in Vercel Production and Preview environments whenever those
+environments render deployed content.
 
 ---
 

--- a/docs/superpowers/plans/2026-08-28-published-notion-domain.md
+++ b/docs/superpowers/plans/2026-08-28-published-notion-domain.md
@@ -1,0 +1,170 @@
+# Published Notion Domain Content Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make production Notion article and static-page bodies render by routing `notion-client` through the published Notion workspace domain.
+
+**Architecture:** Keep `notion-client.getPage()` and `react-notion-x` unchanged at the renderer boundary. Centralize published-domain URL normalization in `lib/notion-api.ts`; content cache wrappers continue calling the shared client. Content failures remain isolated from metadata and render a visible, non-sensitive fallback.
+
+**Tech Stack:** Next.js App Router, TypeScript strict mode, `notion-client`, `react-notion-x`, `unstable_cache`, Vitest, Bun.
+
+## Global Constraints
+
+- Use TypeScript; no `any`, `@ts-ignore`, or `@ts-expect-error`.
+- Preserve the existing `ExtendedRecordMap` content contract.
+- Never log tokens or full Notion responses.
+- Do not fall back to `https://www.notion.so/api/v3` in production.
+- Use the existing five-minute Notion cache and cache tags.
+- Follow existing named-export and `@/` import conventions.
+
+---
+
+### Task 1: Configure the published Notion API base URL
+
+**Files:**
+- Modify: `lib/notion-api.ts`
+- Modify: `lib/notion-cache.ts` only if its inferred client type requires an explicit import change
+- Test: `tests/unit/lib/notion-api.test.ts`
+- Modify: `.env.example` if present; otherwise document the variable in `docs/WORKFLOW.md`
+
+**Interfaces:**
+- Produces a shared default `NotionAPI` configured with `apiBaseUrl` equal to `${NOTION_PUBLIC_SITE_URL}/api/v3`.
+- Consumes `process.env.NOTION_PUBLIC_SITE_URL`.
+
+- [ ] **Step 1: Write failing URL-normalization tests**
+
+Test that `https://future-shawl-a38.notion.site/` becomes `https://future-shawl-a38.notion.site/api/v3` and that a missing production value throws an actionable configuration error.
+
+- [ ] **Step 2: Run the focused test**
+
+Run: `bun vitest run tests/unit/lib/notion-api.test.ts`
+
+Expected: FAIL because the URL helper and configured client are not implemented.
+
+- [ ] **Step 3: Implement configuration**
+
+Add a small pure helper for URL construction and instantiate `NotionAPI` with:
+
+```ts
+new NotionAPI({ apiBaseUrl: buildNotionApiBaseUrl(process.env.NOTION_PUBLIC_SITE_URL) })
+```
+
+Strip trailing slashes before appending `/api/v3`. In production, throw when the variable is missing. Do not silently use `www.notion.so`.
+
+- [ ] **Step 4: Run focused tests and typecheck through the relevant test path**
+
+Run: `bun vitest run tests/unit/lib/notion-api.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/notion-api.ts tests/unit/lib/notion-api.test.ts .env.example docs/WORKFLOW.md
+git commit -m "fix(cms): use published Notion API domain"
+```
+
+### Task 2: Add an explicit content failure state
+
+**Files:**
+- Modify: `app/posts/[slug]/page.tsx`
+- Modify: `app/posts/[slug]/components/PostPageClient.tsx` or the existing content boundary component
+- Test: `tests/integration/components/PostPageClient.test.tsx`
+
+**Interfaces:**
+- Content success continues receiving the existing `ExtendedRecordMap`.
+- Content failure receives an explicit boolean or `null` state and renders a stable user-facing message without raw errors.
+
+- [ ] **Step 1: Write the failing rendering test**
+
+Render the article with a missing record map and assert that a content-unavailable message is present while the article shell remains mounted.
+
+- [ ] **Step 2: Run the focused test**
+
+Run: `bun vitest run tests/integration/components/PostPageClient.test.tsx`
+
+Expected: FAIL because the current missing-content path renders no explicit state.
+
+- [ ] **Step 3: Implement the fallback**
+
+Keep logging server-side with page ID and hostname only. Pass the failure state to the client boundary and render a concise fallback such as `Article content is temporarily unavailable.` Do not show the Notion URL, stack trace, token, or request payload.
+
+- [ ] **Step 4: Run the focused test**
+
+Run: `bun vitest run tests/integration/components/PostPageClient.test.tsx`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/posts/[slug]/page.tsx app/posts/[slug]/components/PostPageClient.tsx tests/integration/components/PostPageClient.test.tsx
+git commit -m "fix(posts): show content fetch failure state"
+```
+
+### Task 3: Document deployment configuration
+
+**Files:**
+- Modify: `docs/WORKFLOW.md`
+- Modify: `.env.example` if the repository contains one
+
+**Interfaces:**
+- Documents `NOTION_PUBLIC_SITE_URL=https://future-shawl-a38.notion.site` as required for deployed content fetching.
+
+- [ ] **Step 1: Add the environment-variable and publication requirements**
+
+Document that every page rendered through `notion-client` must be published under the configured workspace domain and that the variable must be set in Vercel Production and Preview environments as needed.
+
+- [ ] **Step 2: Check documentation consistency**
+
+Run: `bun vitest run tests/unit/lib/notion-api.test.ts`
+
+Expected: PASS; documentation changes do not alter runtime behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/WORKFLOW.md .env.example
+git commit -m "docs(cms): document published Notion domain"
+```
+
+### Task 4: Verify locally and in production
+
+**Files:**
+- No source changes unless verification exposes a defect.
+
+- [ ] **Step 1: Set the local published-domain variable without committing secrets**
+
+Use the existing published URL in local environment configuration:
+
+```env
+NOTION_PUBLIC_SITE_URL=https://future-shawl-a38.notion.site
+```
+
+- [ ] **Step 2: Run changed-contract tests**
+
+Run: `bun test:run`
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run changed-file lint**
+
+Run ESLint against the changed TypeScript files. Expected: no lint errors. Do not rely on the repository's invalid `next lint` script.
+
+- [ ] **Step 4: Build the application**
+
+Run: `bun run build`
+
+Expected: production build succeeds with TypeScript compilation.
+
+- [ ] **Step 5: Deploy with Vercel environment configuration**
+
+Set `NOTION_PUBLIC_SITE_URL` in the target Vercel environment and redeploy. Cache invalidation without redeployment is insufficient because the client configuration is evaluated by the server bundle.
+
+- [ ] **Step 6: Exercise production article rendering**
+
+Open `/posts/28c06e04-986c-807f-ad37-cef1ab36033a` and verify article body text, headings, related posts, and AI summary behavior. Check Vercel logs for the published-domain endpoint and absence of the previous `www.notion.so/api/v3/loadPageChunk` 403.
+
+- [ ] **Step 7: Exercise one static page and one additional article**
+
+Confirm the shared client configuration works for every `getPage()` consumer, not only the reported article.

--- a/docs/superpowers/specs/2026-08-28-published-notion-domain-design.md
+++ b/docs/superpowers/specs/2026-08-28-published-notion-domain-design.md
@@ -1,0 +1,34 @@
+# Published Notion Domain Content Fetch Design
+
+## Problem
+
+Production article bodies fail to render because `notion-client` posts to Notion's default internal endpoint, `https://www.notion.so/api/v3/loadPageChunk`, and Vercel receives `403 Forbidden`. The same published page accepts the request through the workspace's published domain.
+
+## Decision
+
+Keep the existing `notion-client` and `react-notion-x` record-map rendering pipeline, but configure `NotionAPI` with the published workspace domain from `NOTION_PUBLIC_SITE_URL`.
+
+The client will derive `${NOTION_PUBLIC_SITE_URL}/api/v3`, normalize trailing slashes, and reject missing production configuration rather than silently falling back to `www.notion.so`.
+
+## Scope
+
+- Configure post and static-page content fetching through the published Notion domain.
+- Preserve existing cache keys, five-minute cache lifetime, record-map shape, and renderer.
+- Make content-fetch failure visible instead of rendering an indistinguishable empty article.
+- Add unit/integration coverage for URL construction, client configuration, and the failure state.
+- Document the required Vercel environment variable.
+
+## Non-goals
+
+- Do not migrate to the official block API in this fix.
+- Do not build an official-block-to-`ExtendedRecordMap` adapter.
+- Do not add retries for deterministic `403` responses.
+- Do not expose Notion credentials or internal error details to visitors.
+
+## Error behavior
+
+Metadata and related-post behavior remain independent from content rendering. If content fetching fails, the article renders its existing shell and a clear content-unavailable state. The server logs the page ID and endpoint host for diagnosis.
+
+## Validation
+
+The affected production URL must render article body text after deployment. Logs must show requests using the published-domain API base and no `www.notion.so/api/v3/loadPageChunk` 403 for published pages.

--- a/lib/notion-api.ts
+++ b/lib/notion-api.ts
@@ -1,6 +1,11 @@
 import { NotionAPI } from "notion-client";
 
-export const buildNotionApiBaseUrl = (publishedSiteUrl: string | undefined): string => {
+const INVALID_PUBLISHED_SITE_URL_ERROR =
+  "NOTION_PUBLIC_SITE_URL must be an HTTP(S) origin URL";
+
+export const buildNotionApiBaseUrl = (
+  publishedSiteUrl: string | undefined,
+): string => {
   if (!publishedSiteUrl) {
     if (process.env.NODE_ENV === "production") {
       throw new Error("NOTION_PUBLIC_SITE_URL must be set in production");
@@ -9,7 +14,25 @@ export const buildNotionApiBaseUrl = (publishedSiteUrl: string | undefined): str
     return "https://www.notion.so/api/v3";
   }
 
-  return `${publishedSiteUrl.replace(/\/+$/, "")}/api/v3`;
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(publishedSiteUrl);
+  } catch {
+    throw new Error(INVALID_PUBLISHED_SITE_URL_ERROR);
+  }
+
+  if (
+    (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") ||
+    parsedUrl.pathname !== "/" ||
+    parsedUrl.search ||
+    parsedUrl.hash ||
+    parsedUrl.username ||
+    parsedUrl.password
+  ) {
+    throw new Error(INVALID_PUBLISHED_SITE_URL_ERROR);
+  }
+
+  return new URL("/api/v3", parsedUrl.origin).toString();
 };
 
 const api = new NotionAPI({

--- a/lib/notion-api.ts
+++ b/lib/notion-api.ts
@@ -1,5 +1,19 @@
 import { NotionAPI } from "notion-client";
 
-const api = new NotionAPI();
+export const buildNotionApiBaseUrl = (publishedSiteUrl: string | undefined): string => {
+  if (!publishedSiteUrl) {
+    if (process.env.NODE_ENV === "production") {
+      throw new Error("NOTION_PUBLIC_SITE_URL must be set in production");
+    }
+
+    return "https://www.notion.so/api/v3";
+  }
+
+  return `${publishedSiteUrl.replace(/\/+$/, "")}/api/v3`;
+};
+
+const api = new NotionAPI({
+  apiBaseUrl: buildNotionApiBaseUrl(process.env.NOTION_PUBLIC_SITE_URL),
+});
 
 export default api;

--- a/tests/integration/components/PostPageClient.test.tsx
+++ b/tests/integration/components/PostPageClient.test.tsx
@@ -25,11 +25,11 @@ describe("PostPageClient", () => {
     localStorage.clear();
   });
 
-  it("PP-001: renders article content without requesting AI summary before interaction", () => {
+  it("PP-001: preserves the successful content and summary tree", () => {
     const fetchMock = vi.fn();
     vi.stubGlobal("fetch", fetchMock);
 
-    render(
+    const { container } = render(
       <PostPageClient
         recordMap={{} as ExtendedRecordMap}
         slug="test-slug"
@@ -40,15 +40,19 @@ describe("PostPageClient", () => {
       "Article content",
     );
     expect(screen.getByTestId("ai-summary-popup-marker")).toBeInTheDocument();
+    expect(container.firstElementChild).toBe(
+      screen.getByTestId("article-content"),
+    );
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  it("PP-002: shows a stable content-unavailable state while preserving the article shell", () => {
+  it("PP-002: shows a stable content-unavailable state for a null record map", () => {
     render(<PostPageClient recordMap={null} slug="test-slug" />);
 
-    expect(screen.getByRole("article")).toBeInTheDocument();
+    expect(screen.queryByRole("article")).not.toBeInTheDocument();
     expect(
       screen.getByText("Article content is temporarily unavailable."),
     ).toBeInTheDocument();
   });
+
 });

--- a/tests/integration/components/PostPageClient.test.tsx
+++ b/tests/integration/components/PostPageClient.test.tsx
@@ -42,4 +42,13 @@ describe("PostPageClient", () => {
     expect(screen.getByTestId("ai-summary-popup-marker")).toBeInTheDocument();
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("PP-002: shows a stable content-unavailable state while preserving the article shell", () => {
+    render(<PostPageClient recordMap={null} slug="test-slug" />);
+
+    expect(screen.getByRole("article")).toBeInTheDocument();
+    expect(
+      screen.getByText("Article content is temporarily unavailable."),
+    ).toBeInTheDocument();
+  });
 });

--- a/tests/unit/lib/notion-api.test.ts
+++ b/tests/unit/lib/notion-api.test.ts
@@ -38,6 +38,31 @@ describe("Notion API configuration", () => {
       buildNotionApiBaseUrl("https://future-shawl-a38.notion.site/"),
     ).toBe("https://future-shawl-a38.notion.site/api/v3");
   });
+  it("rejects copied Notion page URLs with a pathname", async () => {
+    process.env.NODE_ENV = "test";
+    const { buildNotionApiBaseUrl } = await import("@/lib/notion-api");
+
+    expect(() =>
+      buildNotionApiBaseUrl(
+        "https://future-shawl-a38.notion.site/8f7c6d5e4b3a2910",
+      ),
+    ).toThrow("NOTION_PUBLIC_SITE_URL must be an HTTP(S) origin URL");
+  });
+
+  it("rejects published site URLs with a query or fragment", async () => {
+    process.env.NODE_ENV = "test";
+    const { buildNotionApiBaseUrl } = await import("@/lib/notion-api");
+
+    expect(() =>
+      buildNotionApiBaseUrl(
+        "https://future-shawl-a38.notion.site?workspace=published",
+      ),
+    ).toThrow("NOTION_PUBLIC_SITE_URL must be an HTTP(S) origin URL");
+    expect(() =>
+      buildNotionApiBaseUrl("https://future-shawl-a38.notion.site#published"),
+    ).toThrow("NOTION_PUBLIC_SITE_URL must be an HTTP(S) origin URL");
+  });
+
 
   it("throws an actionable error when the published site URL is missing in production", async () => {
     process.env.NODE_ENV = "production";

--- a/tests/unit/lib/notion-api.test.ts
+++ b/tests/unit/lib/notion-api.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { notionApiConstructorMock } = vi.hoisted(() => ({
+  notionApiConstructorMock: vi.fn(),
+}));
+
+vi.mock("notion-client", () => ({
+  NotionAPI: notionApiConstructorMock,
+}));
+
+const originalNodeEnv = process.env.NODE_ENV;
+const originalPublishedSiteUrl = process.env.NOTION_PUBLIC_SITE_URL;
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+
+  if (originalNodeEnv === undefined) {
+    delete process.env.NODE_ENV;
+  } else {
+    process.env.NODE_ENV = originalNodeEnv;
+  }
+
+  if (originalPublishedSiteUrl === undefined) {
+    delete process.env.NOTION_PUBLIC_SITE_URL;
+  } else {
+    process.env.NOTION_PUBLIC_SITE_URL = originalPublishedSiteUrl;
+  }
+});
+
+describe("Notion API configuration", () => {
+  it("normalizes a published site URL to its API base URL", async () => {
+    process.env.NODE_ENV = "test";
+    // Dynamic imports let each test set process.env before module initialization.
+    const { buildNotionApiBaseUrl } = await import("@/lib/notion-api");
+
+    expect(
+      buildNotionApiBaseUrl("https://future-shawl-a38.notion.site/"),
+    ).toBe("https://future-shawl-a38.notion.site/api/v3");
+  });
+
+  it("throws an actionable error when the published site URL is missing in production", async () => {
+    process.env.NODE_ENV = "production";
+    delete process.env.NOTION_PUBLIC_SITE_URL;
+
+    await expect(import("@/lib/notion-api")).rejects.toThrow(
+      "NOTION_PUBLIC_SITE_URL must be set in production",
+    );
+  });
+
+  it("configures the shared Notion client with the published domain", async () => {
+    process.env.NODE_ENV = "production";
+    process.env.NOTION_PUBLIC_SITE_URL =
+      "https://future-shawl-a38.notion.site/";
+
+    await import("@/lib/notion-api");
+
+    expect(notionApiConstructorMock).toHaveBeenCalledWith({
+      apiBaseUrl: "https://future-shawl-a38.notion.site/api/v3",
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n- route notion-client content requests through the published Notion workspace domain\n- validate the configured public URL and avoid a production fallback to www.notion.so\n- show an explicit content-unavailable state while preserving successful article markup\n- sanitize content-fetch logs\n\n## Verification\n- bun test:run — 26 files, 184 tests passed\n- changed-file ESLint passed\n- production build compiled successfully\n\n## Deployment\nSet NOTION_PUBLIC_SITE_URL=https://future-shawl-a38.notion.site in Vercel Production before redeploying.